### PR TITLE
use IO::Buffer

### DIFF
--- a/nat.rb
+++ b/nat.rb
@@ -27,7 +27,7 @@ class Nat
       return unless entry
 
       entry.packets_sent += 1
-      entry.bytes_sent += packet.bytes.length
+      entry.bytes_sent += packet.bytes.size
       packet.src_addr = @global_addr
       packet.l4.src_port = entry.global_port
     else
@@ -35,7 +35,7 @@ class Nat
       return unless entry
 
       entry.packets_received += 1
-      entry.bytes_received += packet.bytes.length
+      entry.bytes_received += packet.bytes.size
       packet.dest_addr = entry.local_addr
       packet.l4.dest_port = entry.local_port
     end
@@ -59,7 +59,7 @@ class Nat
     return if entry.nil?
 
     entry.packets_received += 1
-    entry.bytes_received += packet.bytes.length
+    entry.bytes_received += packet.bytes.size
     packet.l4.original.src_addr = entry.local_addr
     packet.l4.original.l4.src_port = entry.local_port
     packet.dest_addr = entry.local_addr

--- a/nattable.rb
+++ b/nattable.rb
@@ -164,19 +164,48 @@ class SymmetricNATTable < NATTable
   end
 
   def local_key_from_packet(packet)
-    packet.tuple + packet.l4.tuple
+    l3_tuple = packet.tuple
+    l3_tuple_size = l3_tuple.size
+
+    b = IO::Buffer.new(l3_tuple_size + 4)
+    b.copy(l3_tuple)
+    b.copy(packet.l4.tuple, l3_tuple_size)
+
+    b.get_string
   end
 
   def local_key_from_tuple(local_addr, local_port, remote_addr, remote_port)
-    local_addr + remote_addr + [local_port, remote_port].pack('n*')
+    addr_size = local_addr.size
+
+    b = IO::Buffer.new(addr_size * 2 + 4)
+    b.copy(local_addr)
+    b.copy(remote_addr, addr_size)
+    b.set_value(:U16, addr_size * 2, local_port)
+    b.set_value(:U16, addr_size * 2 + 2, remote_port)
+
+    b.get_string
   end
 
   def remote_key_from_packet(packet)
-    packet.src_addr + packet.l4.tuple
+    src_addr = packet.src_addr
+    addr_size = src_addr.size
+
+    b = IO::Buffer.new(addr_size + 4)
+    b.copy(src_addr)
+    b.copy(packet.l4.tuple, addr_size)
+
+    b.get_string
   end
 
   def remote_key_from_tuple(global_port, remote_addr, remote_port)
-    remote_addr + [remote_port, global_port].pack('n*')
+    addr_size = remote_addr.size
+
+    b = IO::Buffer.new(addr_size + 4)
+    b.copy(remote_addr)
+    b.set_value(:U16, addr_size, remote_port)
+    b.set_value(:U16, addr_size + 2, global_port)
+
+    b.get_string
   end
 end
 
@@ -195,11 +224,17 @@ class ConeNATTable < NATTable
   end
 
   def local_key_from_packet(packet)
-    packet.src_addr + [packet.l4.src_port].pack('n')
+    local_key_from_tuple(packet.src_addr, packet.l4.src_port, nil, nil)
   end
 
   def local_key_from_tuple(local_addr, local_port, _remote_addr, _remote_port)
-    local_addr + [local_port].pack('n')
+    addr_size = local_addr.size
+
+    b = IO::Buffer.new(addr_size + 2)
+    b.copy(local_addr)
+    b.set_value(:U16, addr_size, local_port)
+
+    b.get_string
   end
 
   def remote_key_from_packet(packet)

--- a/nattable.rb
+++ b/nattable.rb
@@ -121,10 +121,10 @@ class NATTable
 
   def _insert(local_addr, local_port, global_port, remote_addr, remote_port)
     entry = Entry.new
-    entry.local_addr = local_addr
+    entry.local_addr = local_addr.dup
     entry.local_port = local_port
     entry.global_port = global_port
-    entry.remote_addr = remote_addr
+    entry.remote_addr = remote_addr.dup
     entry.remote_port = remote_port
 
     entry.link(@anchor)

--- a/rat.rb
+++ b/rat.rb
@@ -39,7 +39,7 @@ end
 $nat = Nat.new
 
 # global address is 192.168.0.137
-$nat.global_addr = "\xc0\xa8\x0\x89".b
+$nat.global_addr = IO::Buffer.for("\xc0\xa8\x0\x89".b)
 
 # create TCP, UDP, ICMP Echo tables
 $nat.tcp_table = SymmetricNATTable.new('tcp')

--- a/reflector.rb
+++ b/reflector.rb
@@ -8,8 +8,8 @@
 
 require './tun'
 
-TRUE_ADDR = "\xa\1\2\xfe".b
-FAKE_ADDR = "\xa\1\2\4".b
+TRUE_ADDR = IO::Buffer.for("\xa\1\2\xfe".b)
+FAKE_ADDR = IO::Buffer.for("\xa\1\2\4".b)
 
 tun = Tun.new('rat')
 loop do

--- a/tun.rb
+++ b/tun.rb
@@ -130,7 +130,7 @@ class IP
 
     def self.icmp_cs_delta(packet)
       upper_layer_packet_length = packet.bytes.length - packet.l4_start
-      packet.tuple.unpack('n*').sum + upper_layer_packet_length + packet.proto
+      IP.sum16(packet.tuple, 0, packet.tuple.size) + sum + upper_layer_packet_length + packet.proto
     end
 
     def self.new_icmp(packet, type)

--- a/tun.rb
+++ b/tun.rb
@@ -240,7 +240,7 @@ class IP
     l4.apply(@l4_cs_delta)
   end
 
-  def self.sum16(bytes, from = nil, len = nil)
+  def self.sum16(bytes, from, len)
     sum = 0
     to = from + len
 

--- a/tun.rb
+++ b/tun.rb
@@ -240,7 +240,11 @@ class IP
     end
     sum += bytes.get_value(:U8, from) * 256 if len.odd?
 
-    ~((sum >> 16) + sum) & 0xffff
+    while sum > 65535
+      sum = (sum & 0xffff) + (sum >> 16)
+    end
+
+    ~sum & 0xffff
   end
 
   # fom RFC 3022 4.2
@@ -251,22 +255,20 @@ class IP
     len = old_bytes.size
     while off < len
       sum -= old_bytes.get_value(:U16, off)
-      if sum <= 0
-        sum -= 1
-        sum &= 0xffff
-      end
       off += 2
+    end
+    while sum < 0
+      sum = (sum & 0xffff) + (sum >> 16)
     end
 
     off = 0
     len = new_bytes.size
     while off < len
       sum += new_bytes.get_value(:U16, off)
-      if sum >= 0x10000
-        sum += 1
-        sum &= 0xffff
-      end
       off += 2
+    end
+    while sum > 65535
+      sum = (sum & 0xffff) + (sum >> 16)
     end
 
     ~sum & 0xffff

--- a/tun.rb
+++ b/tun.rb
@@ -192,7 +192,7 @@ class IP
 
   def src_addr
     addr_size = @version.addr_size
-    @pseudo_header.slice(0, addr_size).dup # cannot freeze a slice?
+    @pseudo_header.slice(0, addr_size)
   end
 
   def src_addr=(x)
@@ -202,7 +202,7 @@ class IP
 
   def dest_addr
     addr_size = @version.addr_size
-    @pseudo_header.slice(addr_size, addr_size).dup
+    @pseudo_header.slice(addr_size, addr_size)
   end
 
   def dest_addr=(x)
@@ -212,7 +212,7 @@ class IP
 
   def tuple
     addr_size = @version.addr_size
-    @pseudo_header.slice(0, addr_size * 2).dup
+    @pseudo_header.slice(0, addr_size * 2)
   end
 
   def l4_length

--- a/tun.rb
+++ b/tun.rb
@@ -302,7 +302,7 @@ class TCPUDP
   end
 
   def tuple
-    @packet.bytes.slice(@packet.l4_start, 4).dup
+    @packet.bytes.slice(@packet.l4_start, 4)
   end
 
   def _apply(checksum_offset)


### PR DESCRIPTION
Use IO::Buffer for retaining packet image as well as internal structures (e.g., pseudo header, L4 port tuple).

Benchmark results:
||main|IO::Buffer|
|:---:|:---:|:---:|
|reflector (Core i5-1240p, bare metal)|1.57Gbps|1.79Gbps|
|NAT (Core i7-9750H, VMware fusion to host)|182Mbps|183Mbps|