### PR TITLE
fix incorrect checksum when adjustment underflows

### DIFF
--- a/tun.rb
+++ b/tun.rb
@@ -269,7 +269,17 @@ class IP
   def self.checksum_adjust(sum, delta)
     sum = ~sum & 0xffff
     sum += delta
-    sum = (sum & 0xffff) + (sum >> 16) while sum < 0 || sum > 65535
+    if sum > 65535
+      loop do
+        sum = (sum & 0xffff) + (sum >> 16)
+        break unless sum > 65535
+      end
+    elsif sum <= 0
+      loop do
+        sum += 65535 * ((65536 - sum) >> 16)
+        break unless sum <= 0
+        end
+    end
     ~sum & 0xffff
   end
 

--- a/tun.rb
+++ b/tun.rb
@@ -268,18 +268,9 @@ class IP
   # fom RFC 3022 4.2
   def self.checksum_adjust(sum, delta)
     sum = ~sum & 0xffff
+    delta = (delta & 0xffff) + (delta >> 16) while delta < 0 || delta > 65535
     sum += delta
-    if sum > 65535
-      loop do
-        sum = (sum & 0xffff) + (sum >> 16)
-        break unless sum > 65535
-      end
-    elsif sum <= 0
-      loop do
-        sum += 65535 * ((65536 - sum) >> 16)
-        break unless sum <= 0
-        end
-    end
+    sum += sum >> 16
     ~sum & 0xffff
   end
 


### PR DESCRIPTION
Internet Checksum (f(x)) is defined as:

  f(x) = ~f'(x) & 0xffff
  f'(x) = if sum(x) < 65536 ? sum(x) : (sum(x) - 65536) % 65535 + 1

Intermediate value f'(x) iterates from 1 to 65535. Therefore, an intermediate value of zero indicates an underflow.